### PR TITLE
Feature/flake8

### DIFF
--- a/bvh.py
+++ b/bvh.py
@@ -27,11 +27,11 @@ class BvhNode:
         for child in self.children:
             for index, item in enumerate(child.value):
                 if item == key:
-                    if index+1 >= len(child.value):
+                    if index + 1 >= len(child.value):
                         return None
                     else:
-                        return child.value[index+1:]
-        raise IndexError('key {0} not found'.format(key))
+                        return child.value[index + 1:]
+        raise IndexError('key {} not found'.format(key))
 
     def __repr__(self):
         return str(' '.join(self.value))

--- a/bvh.py
+++ b/bvh.py
@@ -55,8 +55,7 @@ class Bvh:
         for char in self.data:
             if char not in ('\n', '\r'):
                 accumulator += char
-            else:
-                if accumulator:
+            elif accumulator:
                     first_round.append(re.split('\\s+', accumulator.strip()))
                     accumulator = ''
         node_stack = [self.root]

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,5 @@ setup(name='bvh',
       author='20Tab S.r.l.',
       author_email='info@20tab.com',
       url='https://github.com/20tab/bvh-python',
-      py_modules=['bvh'])
+      py_modules=['bvh'],
+      )

--- a/tests/test_bvh.py
+++ b/tests/test_bvh.py
@@ -1,4 +1,5 @@
 import unittest
+
 from bvh import Bvh, BvhNode
 
 
@@ -16,12 +17,16 @@ class TestBvh(unittest.TestCase):
     def test_tree(self):
         with open('tests/test_freebvh.bvh') as f:
             mocap = Bvh(f.read())
-        self.assertEqual([str(item) for item in mocap.root], ['HIERARCHY', 'ROOT mixamorig:Hips', 'MOTION', 'Frames: 69', 'Frame Time: 0.0333333'])
+        self.assertEqual([str(item) for item in mocap.root],
+                         ['HIERARCHY', 'ROOT mixamorig:Hips', 'MOTION', 'Frames: 69', 'Frame Time: 0.0333333']
+                         )
 
     def test_tree2(self):
         with open('tests/test_mocapbank.bvh') as f:
             mocap = Bvh(f.read())
-        self.assertEqual([str(item) for item in mocap.root], ['HIERARCHY', 'ROOT Hips', 'MOTION', 'Frames: 455', 'Frame Time: 0.033333'])
+        self.assertEqual([str(item) for item in mocap.root],
+                         ['HIERARCHY', 'ROOT Hips', 'MOTION', 'Frames: 455', 'Frame Time: 0.033333']
+                         )
 
     def test_filter(self):
         with open('tests/test_freebvh.bvh') as f:
@@ -109,7 +114,9 @@ class TestBvh(unittest.TestCase):
         with open('tests/test_mocapbank.bvh') as f:
             mocap = Bvh(f.read())
         self.assertEqual(mocap.joint_channels('LeftElbow'), ['Zrotation', 'Xrotation', 'Yrotation'])
-        self.assertEqual(mocap.joint_channels('Hips'), ['Xposition', 'Yposition', 'Zposition', 'Zrotation', 'Xrotation', 'Yrotation'])
+        self.assertEqual(mocap.joint_channels('Hips'),
+                         ['Xposition', 'Yposition', 'Zposition', 'Zrotation', 'Xrotation', 'Yrotation']
+                         )
 
     def test_frame_channel(self):
         with open('tests/test_mocapbank.bvh') as f:

--- a/tests/test_bvh.py
+++ b/tests/test_bvh.py
@@ -32,6 +32,7 @@ class TestBvh(unittest.TestCase):
         bones = []
         with open('tests/test_freebvh.bvh') as f:
             mocap = Bvh(f.read())
+
         def iterate_joints(joint):
             bones.append(str(joint))
             for child in joint.filter('JOINT'):
@@ -118,7 +119,7 @@ class TestBvh(unittest.TestCase):
         self.assertEqual(mocap.frame_joint_channel(22, 'Neck', 'Xrotation'), -6.77)
         self.assertEqual(mocap.frame_joint_channel(22, 'Head', 'Yrotation'), 8.47)
 
-    def test_frame_channel(self):
+    def test_frame_channel2(self):
         with open('tests/test_freebvh.bvh') as f:
             mocap = Bvh(f.read())
         self.assertEqual(mocap.frame_joint_channel(22, 'mixamorig:Hips', 'Xposition'), 4.3314)
@@ -128,7 +129,7 @@ class TestBvh(unittest.TestCase):
             mocap = Bvh(f.read())
         x_accumulator = 0.0
         for i in range(0, mocap.nframes):
-            x_accumulator += mocap.frame_joint_channel(i, 'Hips', 'Xposition') 
+            x_accumulator += mocap.frame_joint_channel(i, 'Hips', 'Xposition')
         self.assertTrue(abs(-19735.902699999995 - x_accumulator) < 0.0001)
 
     def test_joints_names(self):
@@ -151,16 +152,15 @@ class TestBvh(unittest.TestCase):
     def test_frame_joint_multi_channels(self):
         with open('tests/test_mocapbank.bvh') as f:
             mocap = Bvh(f.read())
-        rotation = mocap.frame_joint_channels(30, 'Head', ['Xrotation', 'Yrotation', 'Zrotation']) 
+        rotation = mocap.frame_joint_channels(30, 'Head', ['Xrotation', 'Yrotation', 'Zrotation'])
         self.assertEqual(rotation, [1.77, 13.94, -7.42])
 
     def test_frames_multi_channels(self):
         with open('tests/test_mocapbank.bvh') as f:
             mocap = Bvh(f.read())
-        rotations = mocap.frames_joint_channels('Head', ['Xrotation', 'Yrotation', 'Zrotation']) 
+        rotations = mocap.frames_joint_channels('Head', ['Xrotation', 'Yrotation', 'Zrotation'])
         self.assertEqual(len(rotations), mocap.nframes)
 
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
- Fix flake8 errors
- Sort import with isort
- Line length at 119 characters (width of GitHub code review)