### PR TITLE
fix last frame in tokenize method

### DIFF
--- a/bvh.py
+++ b/bvh.py
@@ -58,6 +58,10 @@ class Bvh:
             elif accumulator:
                     first_round.append(re.split('\\s+', accumulator.strip()))
                     accumulator = ''
+        else: #at the end of the loop, appends the current contents of the accumulator if it is not empty
+            if accumulator:
+                first_round.append(re.split('\\s+', accumulator.strip()))
+                accumulator = ''
         node_stack = [self.root]
         frame_time_found = False
         node = None


### PR DESCRIPTION
As mentioned in [#7](https://github.com/20tab/bvh-python/issues/7), the last frame is not processed and added to the list of frames if there is no newline at the end of the .bvh file. Adding a simple `else` clause to the loop ensures that we can append the contents of a non-empty `accumulator` to the `first_round` object even without a newline.